### PR TITLE
Shell script to set up the camera to /dev/fourtran_camera

### DIFF
--- a/hardware_layer/hardware_camera/launch/camera.launch
+++ b/hardware_layer/hardware_camera/launch/camera.launch
@@ -1,6 +1,6 @@
 <launch>
   <node name="camera" pkg="usb_cam" type="usb_cam_node" output="screen">
-    <param name="video_device" value="/dev/video1" />
+    <param name="video_device" value="/dev/fourtran_camera" />
     <param name="image_width" value="640" />
     <param name="image_height" value="480" />
     <param name="pixel_format" value="mjpeg" />

--- a/utils/setup_camera.sh
+++ b/utils/setup_camera.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Enter vendor id of the camera"
+read vendorId
+
+echo "Enter product id of the camera"
+read productId
+
+echo "ACTION==\"add\", KERNEL==\"video[0-9]*\", SUBSYSTEM==\"video4linux\", SUBSYSTEMS==\"usb\", ATTRS{idVendor}==\"$vendorId\", ATTRS{idProduct}==\"$productId\", SYMLINK+=\"fourtran_camera\"" >> /etc/udev/rules.d/83-webcam.rules


### PR DESCRIPTION
I have made a `utils` folder than contains a shell script `setup_camera.sh`. This shell script takes input from the user about the vendor ID and the product ID of the camera and writes a rule corresponding to that in `/etc/udev/rules.d/83-webcam.rules`. After that, the camera has to be replugged. The camera feed is then available on `/dev/fourtran_camera`. The `camera.launch` file in `hardware_camera` uses `/dev/fourtran_camera` as the value of `video_device` param. So, executing this shell script is important for running `hardware_camera`.